### PR TITLE
Add support for Godot 4.2

### DIFF
--- a/addons/editor_icon_previewer/editor_icon_previewer.gd
+++ b/addons/editor_icon_previewer/editor_icon_previewer.gd
@@ -44,7 +44,7 @@ func _on_update_requested():
 func _populate_icons():
 	icon_window.clear()
 
-	var godot_theme = get_editor_interface().get_base_control().theme
+	var godot_theme = EditorInterface.get_editor_theme()
 
 	var list = Array(godot_theme.get_icon_list('EditorIcons'))
 	list.sort() # alphabetically
@@ -66,9 +66,9 @@ func _populate_icons():
 
 
 func convert_to_texture():
-	var selected_nodes = get_editor_interface().get_selection().get_transformable_selected_nodes()
+	var selected_nodes = EditorInterface.get_selection().get_transformable_selected_nodes()
 	if selected_nodes.size() > 0:
-		var selected_node = get_editor_interface().get_selection().get_transformable_selected_nodes()[0]
+		var selected_node = EditorInterface.get_selection().get_transformable_selected_nodes()[0]
 		var selected_node_path = selected_node.get_path()
 		var properties = selected_node.get_property_list()
 		

--- a/addons/editor_icon_previewer/editor_icon_window.gd
+++ b/addons/editor_icon_previewer/editor_icon_window.gd
@@ -93,7 +93,7 @@ func _icon_gui_input(event, icon):
 
 func _input(event):
 	if event is InputEventKey and event.is_pressed() and not event.echo:
-		if event.scancode == KEY_I:
+		if event.physical_keycode == KEY_I:
 			if not visible:
 				display()
 			else:

--- a/project.godot
+++ b/project.godot
@@ -6,17 +6,13 @@
 ;   [section] ; section goes between []
 ;   param=value ; assign values to parameters
 
-config_version=4
-
-_global_script_classes=[  ]
-_global_script_class_icons={
-
-}
+config_version=5
 
 [application]
 
 config/name="Editor Icons Previewer"
+config/features=PackedStringArray("4.2")
 
 [editor_plugins]
 
-enabled=PoolStringArray( "editor_icon_previewer" )
+enabled=PackedStringArray("editor_icon_previewer")


### PR DESCRIPTION
## NOTE:
This PR is targeted at the gd4 branch, but should probably be targeted to a new branch based off of gd4 if approved. It seems 4.2 bumped the config_version in `project.godot`. These changes won't be backwards compatible with releases earlier than 4.2.

---

This should fix #8 

### Changes:

* The `Control` returned from `.get_base_control()` doesn't seem to have the base editor theme assigned to it in Godot 4.2 and returns null. This resulted in no icons appearing in the editor icon window.
`EditorInterface.get_editor_theme()` seems to have been added in 4.2 based on it not existing in docs for 4.1 or earlier.

* The `.get_selection()` function also seems to have been made static in 4.2 so those calls have been changed to match that.